### PR TITLE
Change commit_message to full_commit_message in gh-pages deployment action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
         publish_dir: .
         user_name: 'github-actions[bot]'
         user_email: 'github-actions[bot]@users.noreply.github.com'
-        commit_message: ${{ steps.commit_message.outputs.message }}
+        full_commit_message: ${{ steps.commit_message.outputs.message }}


### PR DESCRIPTION
> To set a full custom commit message without a triggered commit hash, use the full_commit_message option instead of the commit_message option.

https://github.com/peaceiris/actions-gh-pages?tab=readme-ov-file#%EF%B8%8F-set-custom-commit-message